### PR TITLE
feat: Use SVG icons for social media links in Contact section

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,15 +10,28 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     <link rel="stylesheet" href="light-theme.css">
     <style>
-      /* Styles for minimal contact section - can be expanded later */
-      .contact-minimal a {
-        display: block;
-        margin-bottom: 10px;
+      /* Styles for minimal contact section */
+      .contact-minimal .social-link { /* Changed from 'a' to a class for more specificity if needed */
+        display: inline-block; /* Icons side-by-side */
+        margin: 0 10px 10px 0; /* Margin for spacing: top, right, bottom, left */
         text-decoration: none;
+        vertical-align: middle; /* Align icons nicely if their heights differ slightly or text is beside */
       }
-      .contact-minimal a:hover {
-        text-decoration: underline;
+      .contact-minimal .social-link:last-child {
+        margin-right: 0; /* No right margin on the last icon */
       }
+      .contact-minimal .social-link:hover .social-icon {
+        opacity: 0.8; /* Slight opacity change on hover for feedback */
+      }
+      .social-icon {
+        /* The width and height are set on the SVG elements directly (24px) */
+        /* vertical-align: middle; /* Already on social-link, but can be here too if needed */
+      }
+      /* Ensure theme specific fills if we want to override parts of SVGs, though these are brand colors */
+      /* Example for Facebook icon if we wanted its white 'f' to change with theme's text color */
+      /* .light-theme .fb-icon-path { fill: #212529; } */
+      /* .dark-theme .fb-icon-path { fill: #f8f9fa; } */
+      /* This would require adding a class like 'fb-icon-path' to the <path> element in the FB SVG */
       /* Basic page styling */
       .about-container {
         padding-top: 20px;
@@ -76,8 +89,27 @@
 
         <div class="about-section contact-minimal" id="contact-section">
             <h2>Contact</h2>
-            <a href="https://www.facebook.com/sweetcandyaum/" target="_blank">Facebook</a>
-            <a href="https://www.instagram.com/IAMYOURAUM/" target="_blank">Instagram (@IAMYOURAUM)</a>
+            <a href="https://www.facebook.com/sweetcandyaum/" target="_blank" aria-label="Facebook Profile" class="social-link">
+                <!-- Facebook Icon SVG -->
+                <svg version="1.2" baseProfile="tiny" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 36 36" xml:space="preserve" class="social-icon">
+                  <rect fill="#3B5998" width="36" height="36"/>
+                  <path fill="#FFFFFF" d="M30.895,16.535l-0.553,5.23h-4.181v15.176h-6.28V21.766H16.75v-5.23h3.131v-3.149 c0-4.254,1.768-6.796,6.796-6.796h4.181v5.23h-2.615c-1.952,0-2.081,0.736-2.081,2.1v2.615H30.895z"/>
+                </svg>
+            </a>
+            <a href="https://www.instagram.com/IAMYOURAUM/" target="_blank" aria-label="Instagram Profile" class="social-link">
+                <!-- Instagram Icon SVG -->
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 132 132" class="social-icon">
+                  <defs>
+                    <linearGradient id="insta-b-unique"> <stop offset="0" stop-color="#3771c8"/> <stop stop-color="#3771c8" offset=".128"/> <stop offset="1" stop-color="#60f" stop-opacity="0"/> </linearGradient>
+                    <linearGradient id="insta-a-unique"> <stop offset="0" stop-color="#fd5"/> <stop offset=".1" stop-color="#fd5"/> <stop offset=".5" stop-color="#ff543e"/> <stop offset="1" stop-color="#c837ab"/> </linearGradient>
+                    <radialGradient id="insta-c-unique" cx="158.429" cy="578.088" r="65" xlink:href="#insta-a-unique" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0 -1.98198 1.8439 0 -1031.402 454.004)" fx="158.429" fy="578.088"/>
+                    <radialGradient id="insta-d-unique" cx="147.694" cy="473.455" r="65" xlink:href="#insta-b-unique" gradientUnits="userSpaceOnUse" gradientTransform="matrix(.17394 .86872 -3.5818 .71718 1648.348 -458.493)" fx="147.694" fy="473.455"/>
+                  </defs>
+                  <path fill="url(#insta-c-unique)" d="M65.03 0C37.888 0 29.95.028 28.407.156c-5.57.463-9.036 1.34-12.812 3.22-2.91 1.445-5.205 3.12-7.47 5.468C4 13.126 1.5 18.394.595 24.656c-.44 3.04-.568 3.66-.594 19.188-.01 5.176 0 11.988 0 21.125 0 27.12.03 35.05.16 36.59.45 5.42 1.3 8.83 3.1 12.56 3.44 7.14 10.01 12.5 17.75 14.5 2.68.69 5.64 1.07 9.44 1.25 1.61.07 18.02.12 34.44.12 16.42 0 32.84-.02 34.41-.1 4.4-.207 6.955-.55 9.78-1.28 7.79-2.01 14.24-7.29 17.75-14.53 1.765-3.64 2.66-7.18 3.065-12.317.088-1.12.125-18.977.125-36.81 0-17.836-.04-35.66-.128-36.78-.41-5.22-1.305-8.73-3.127-12.44-1.495-3.037-3.155-5.305-5.565-7.624C116.9 4 111.64 1.5 105.372.596 102.335.157 101.73.027 86.19 0H65.03z" transform="translate(1.004 1)"/>
+                  <path fill="url(#insta-d-unique)" d="M65.03 0C37.888 0 29.95.028 28.407.156c-5.57.463-9.036 1.34-12.812 3.22-2.91 1.445-5.205 3.12-7.47 5.468C4 13.126 1.5 18.394.595 24.656c-.44 3.04-.568 3.66-.594 19.188-.01 5.176 0 11.988 0 21.125 0 27.12.03 35.05.16 36.59.45 5.42 1.3 8.83 3.1 12.56 3.44 7.14 10.01 12.5 17.75 14.5 2.68.69 5.64 1.07 9.44 1.25 1.61.07 18.02.12 34.44.12 16.42 0 32.84-.02 34.41-.1 4.4-.207 6.955-.55 9.78-1.28 7.79-2.01 14.24-7.29 17.75-14.53 1.765-3.64 2.66-7.18 3.065-12.317.088-1.12.125-18.977.125-36.81 0-17.836-.04-35.66-.128-36.78-.41-5.22-1.305-8.73-3.127-12.44-1.495-3.037-3.155-5.305-5.565-7.624C116.9 4 111.64 1.5 105.372.596 102.335.157 101.73.027 86.19 0H65.03z" transform="translate(1.004 1)"/>
+                  <path fill="#fff" d="M66.004 18c-13.036 0-14.672.057-19.792.29-5.11.234-8.598 1.043-11.65 2.23-3.157 1.226-5.835 2.866-8.503 5.535-2.67 2.668-4.31 5.346-5.54 8.502-1.19 3.053-2 6.542-2.23 11.65C18.06 51.327 18 52.964 18 66s.058 14.667.29 19.787c.235 5.11 1.044 8.598 2.23 11.65 1.227 3.157 2.867 5.835 5.536 8.503 2.667 2.67 5.345 4.314 8.5 5.54 3.054 1.187 6.543 1.996 11.652 2.23 5.12.233 6.755.29 19.79.29 13.037 0 14.668-.057 19.788-.29 5.11-.234 8.602-1.043 11.656-2.23 3.156-1.226 5.83-2.87 8.497-5.54 2.67-2.668 4.31-5.346 5.54-8.502 1.18-3.053 1.99-6.542 2.23-11.65.23-5.12.29-6.752.29-19.788 0-13.036-.06-14.672-.29-19.792-.24-5.11-1.05-8.598-2.23-11.65-1.23-3.157-2.87-5.835-5.54-8.503-2.67-2.67-5.34-4.31-8.5-5.535-3.06-1.187-6.55-1.996-11.66-2.23-5.12-.233-6.75-.29-19.79-.29zm-4.306 8.65c1.278-.002 2.704 0 4.306 0 12.816 0 14.335.046 19.396.276 4.68.214 7.22.996 8.912 1.653 2.24.87 3.837 1.91 5.516 3.59 1.68 1.68 2.72 3.28 3.592 5.52.657 1.69 1.44 4.23 1.653 8.91.23 5.06.28 6.58.28 19.39s-.05 14.33-.28 19.39c-.214 4.68-.996 7.22-1.653 8.91-.87 2.24-1.912 3.835-3.592 5.514-1.68 1.68-3.275 2.72-5.516 3.59-1.69.66-4.232 1.44-8.912 1.654-5.06.23-6.58.28-19.396.28-12.817 0-14.336-.05-19.396-.28-4.68-.216-7.22-.998-8.913-1.655-2.24-.87-3.84-1.91-5.52-3.59-1.68-1.68-2.72-3.276-3.592-5.517-.657-1.69-1.44-4.23-1.653-8.91-.23-5.06-.276-6.58-.276-19.398s.046-14.33.276-19.39c.214-4.68.996-7.22 1.653-8.912.87-2.24 1.912-3.84 3.592-5.52 1.68-1.68 3.28-2.72 5.52-3.592 1.692-.66 4.233-1.44 8.913-1.655 4.428-.2 6.144-.26 15.09-.27zm29.928 7.97c-3.18 0-5.76 2.577-5.76 5.758 0 3.18 2.58 5.76 5.76 5.76 3.18 0 5.76-2.58 5.76-5.76 0-3.18-2.58-5.76-5.76-5.76zm-25.622 6.73c-13.613 0-24.65 11.037-24.65 24.65 0 13.613 11.037 24.645 24.65 24.645C79.617 90.645 90.65 79.613 90.65 66S79.616 41.35 66.003 41.35zm0 8.65c8.836 0 16 7.163 16 16 0 8.836-7.164 16-16 16-8.837 0-16-7.164-16-16 0-8.837 7.163-16 16-16z"/>
+                </svg>
+            </a>
         </div>
     </div>
 


### PR DESCRIPTION
This commit updates the "About Me" page to use SVG icons for Facebook and Instagram links in the Contact section, replacing the previous text links. This provides a cleaner and more minimal visual appearance.

Key changes:
- Embedded SVG code for Facebook and Instagram icons directly into `about.html`.
  - Icons are displayed at a 24x24 pixel size.
  - Added `aria-label` attributes to the icon links for accessibility.
- Updated inline CSS in `about.html`:
  - Styled the icon links (`.social-link`) to be `inline-block` for side-by-side display.
  - Added margins for spacing between icons.
  - Implemented a subtle opacity change on hover for visual feedback.
  - Ensured brand colors of the icons are maintained.

The Contact section now features clickable social media icons, enhancing the page's visual appeal and minimalism.